### PR TITLE
feat: Implement recent activity feature in dashboard

### DIFF
--- a/backend/tests/coupons.test.js
+++ b/backend/tests/coupons.test.js
@@ -1,0 +1,140 @@
+const request = require('supertest');
+const app = require('../app'); // Assuming your Express app is exported from app.js
+const { query: dbQuery, pool } = require('../config/database'); // Assuming pool is exported for graceful shutdown
+
+// Helper function to create coupons for testing
+const createCoupon = async (coupon) => {
+  const {
+    id,
+    code,
+    company,
+    type,
+    category,
+    notes,
+    expiration_date,
+    original_amount,
+    currency = 'NIS',
+    product_description,
+    date_added = new Date() // Default to now if not provided
+  } = coupon;
+  const remaining_amount = type === 'money' ? original_amount : null;
+
+  return dbQuery(`
+    INSERT INTO coupons (
+        id, code, company, type, original_amount, remaining_amount,
+        currency, product_description, category, expiration_date, notes, date_added
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    RETURNING *
+  `, [
+    id, code, company, type, original_amount, remaining_amount,
+    currency, product_description, category, expiration_date, notes, date_added
+  ]);
+};
+
+describe('Coupon API - Recent Endpoint', () => {
+  const testCoupons = [
+    { id: 'recent-1', code: 'RECENT01', company: 'TestCorp', type: 'money', original_amount: 100, date_added: new Date('2023-01-01T10:00:00Z') },
+    { id: 'recent-2', code: 'RECENT02', company: 'TestCorp', type: 'product', product_description: 'Free Tea', date_added: new Date('2023-01-02T10:00:00Z') },
+    { id: 'recent-3', code: 'RECENT03', company: 'AnotherCo', type: 'money', original_amount: 50, date_added: new Date('2023-01-03T10:00:00Z') },
+    { id: 'recent-4', code: 'RECENT04', company: 'TestCorp', type: 'money', original_amount: 20, date_added: new Date('2023-01-04T10:00:00Z') },
+    { id: 'recent-5', code: 'RECENT05', company: 'SuperStore', type: 'product', product_description: 'Free Coffee', date_added: new Date('2023-01-05T10:00:00Z') },
+    { id: 'recent-6', code: 'RECENT06', company: 'TestCorp', type: 'money', original_amount: 10, date_added: new Date('2023-01-06T10:00:00Z') },
+    { id: 'recent-7', code: 'RECENT07', company: 'OldCoupon', type: 'money', original_amount: 5, date_added: new Date('2022-12-31T10:00:00Z') },
+  ];
+
+  beforeAll(async () => {
+    // In a real setup, you might point to a separate test database
+    // For now, we assume the dev DB is used and we clean up
+    await dbQuery('DELETE FROM coupon_usage');
+    await dbQuery('DELETE FROM coupons');
+  });
+
+  beforeEach(async () => {
+    await dbQuery('DELETE FROM coupon_usage');
+    await dbQuery('DELETE FROM coupons');
+    // Insert test data, unsorted by date_added to ensure endpoint sorts them
+    const shuffledCoupons = [...testCoupons].sort(() => Math.random() - 0.5);
+    for (const coupon of shuffledCoupons) {
+      await createCoupon(coupon);
+    }
+  });
+
+  afterEach(async () => {
+    await dbQuery('DELETE FROM coupon_usage');
+    await dbQuery('DELETE FROM coupons');
+  });
+
+  afterAll(async () => {
+    // Close the database pool
+    if (pool && pool.end) {
+      await pool.end();
+    }
+  });
+
+  describe('GET /api/coupons/recent', () => {
+    it('should return 200 OK and a JSON array', async () => {
+      const response = await request(app)
+        .get('/api/coupons/recent')
+        .expect('Content-Type', /json/)
+        .expect(200);
+      expect(Array.isArray(response.body)).toBe(true);
+    });
+
+    it('should return at most 5 coupons', async () => {
+      const response = await request(app).get('/api/coupons/recent');
+      expect(response.body.length).toBeLessThanOrEqual(5);
+      // Ensure we have more than 5 coupons in test data to make this test meaningful
+      expect(testCoupons.length).toBeGreaterThan(5);
+       // Specifically, it should be 5 if more than 5 are available
+      const activeTestCoupons = testCoupons.filter(c => new Date(c.date_added) > new Date('2022-12-31T23:59:59Z')); // Filter out very old ones if any logic changes
+      if (activeTestCoupons.length >= 5) {
+        expect(response.body.length).toBe(5);
+      } else {
+        expect(response.body.length).toBe(activeTestCoupons.length);
+      }
+    });
+
+    it('should return coupons sorted by date_added descending', async () => {
+      const response = await request(app).get('/api/coupons/recent');
+      const recentCoupons = response.body;
+      expect(recentCoupons.length).toBeGreaterThan(0); // Ensure we have data to test sorting
+
+      for (let i = 0; i < recentCoupons.length - 1; i++) {
+        const date1 = new Date(recentCoupons[i].date_added);
+        const date2 = new Date(recentCoupons[i+1].date_added);
+        expect(date1.getTime()).toBeGreaterThanOrEqual(date2.getTime());
+      }
+
+      // Verify the top items are indeed the most recent ones from testCoupons
+      const sortedTestCoupons = [...testCoupons]
+        .sort((a, b) => new Date(b.date_added).getTime() - new Date(a.date_added).getTime())
+        .slice(0, 5);
+
+      recentCoupons.forEach((coupon, index) => {
+        expect(coupon.id).toBe(sortedTestCoupons[index].id);
+        expect(coupon.code).toBe(sortedTestCoupons[index].code);
+      });
+    });
+
+    it('should return an empty array if no coupons exist', async () => {
+      // Clear all coupons first
+      await dbQuery('DELETE FROM coupons');
+      const response = await request(app).get('/api/coupons/recent');
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual([]);
+    });
+
+    it('should include the status field for each coupon', async () => {
+        const response = await request(app).get('/api/coupons/recent');
+        expect(response.status).toBe(200);
+        expect(response.body.length).toBeGreaterThan(0);
+        response.body.forEach(coupon => {
+          expect(coupon.status).toBeDefined();
+          // Add more specific status checks if needed, e.g. for an active coupon
+          if (coupon.id === 'recent-6') { // RECENT06 is expected to be active
+            expect(coupon.status).toBe('active');
+          }
+        });
+      });
+  });
+});

--- a/frontend/src/components/LoadingSpinner.tsx
+++ b/frontend/src/components/LoadingSpinner.tsx
@@ -12,7 +12,7 @@ const LoadingSpinner: React.FC<LoadingSpinnerProps> = ({ size = 'md' }) => {
   };
 
   return (
-    <div className="flex justify-center">
+    <div className="flex justify-center" data-testid="loading-spinner">
       <div
         className={`${sizeClasses[size]} animate-spin rounded-full border-2 border-gray-300 border-t-primary-600`}
       />

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { BrowserRouter as Router } from 'react-router-dom'; // For <Link> components if any are rendered indirectly
+import Dashboard from './Dashboard'; // Corrected: Dashboard is a default export
+import { couponApi } from '../services/api';
+import { Coupon, CouponStats } from '../types';
+
+// Mock the entire couponApi service
+jest.mock('../services/api', () => ({
+  ...jest.requireActual('../services/api'), // Import and retain default exports
+  couponApi: {
+    getStats: jest.fn(),
+    getRecentCoupons: jest.fn(),
+    // Mock other functions if Dashboard uses them, otherwise this is fine
+  },
+}));
+
+const mockStats: CouponStats = {
+  total_coupons: 10,
+  active_money_coupons: 5,
+  active_product_coupons: 3,
+  expiring_soon: 2,
+  total_value: 500,
+  total_companies: 4,
+  total_categories: 6,
+};
+
+const mockRecentCoupons: Coupon[] = [
+  {
+    id: '1',
+    code: 'RECENT01',
+    company: 'TestCo A',
+    type: 'money',
+    original_amount: 100,
+    remaining_amount: 100,
+    currency: 'USD',
+    date_added: new Date('2023-10-01T10:00:00Z').toISOString(),
+    status: 'active',
+    is_used: false,
+  },
+  {
+    id: '2',
+    code: 'RECENT02',
+    company: 'TestCo B',
+    type: 'product',
+    product_description: 'Free Drink',
+    date_added: new Date('2023-09-30T12:00:00Z').toISOString(),
+    status: 'active',
+    is_used: false,
+  },
+];
+
+describe('Dashboard - Recent Activity Section', () => {
+  beforeEach(() => {
+    // Reset mocks before each test
+    (couponApi.getStats as jest.Mock).mockReset();
+    (couponApi.getRecentCoupons as jest.Mock).mockReset();
+
+    // Default successful mock for getStats to avoid unrelated errors in tests focused on recent activity
+    (couponApi.getStats as jest.Mock).mockResolvedValue(mockStats);
+  });
+
+  const renderDashboard = () => {
+    // Wrap with Router if Link components are used, e.g. in Quick Actions
+    // The Dashboard itself doesn't use routing but sub-components or links might
+    return render(
+      <Router>
+        <Dashboard />
+      </Router>
+    );
+  };
+
+  test('shows loading state initially for recent activity', async () => {
+    (couponApi.getRecentCoupons as jest.Mock).mockImplementation(() => {
+      return new Promise(() => {}); // Never resolves, stays in loading
+    });
+    renderDashboard();
+
+    // Check for stats loading first (as per component logic)
+    await waitFor(() => expect(couponApi.getStats).toHaveBeenCalled());
+    // Then check for recent activity section specific loading
+    // Assuming a specific loading spinner or text for this section.
+    // The component uses a generic LoadingSpinner, so we check if it's there while recentCoupons is null
+    // and loadingRecent is true (internal state, harder to check directly).
+    // We'll look for the "Recent Activity" heading and then expect a spinner within that card.
+    expect(screen.getByText('Recent Activity')).toBeInTheDocument();
+    // Let's assume the spinner inside the "Recent Activity" card would be identifiable
+    // For now, we'll check that data is NOT yet there.
+    expect(screen.queryByText('RECENT01')).not.toBeInTheDocument();
+  });
+
+  test('displays recent coupons correctly after successful fetch', async () => {
+    (couponApi.getRecentCoupons as jest.Mock).mockResolvedValue(mockRecentCoupons);
+    renderDashboard();
+
+    await waitFor(() => expect(couponApi.getRecentCoupons).toHaveBeenCalled());
+
+    expect(screen.getByText('RECENT01')).toBeInTheDocument();
+    expect(screen.getByText('TestCo A')).toBeInTheDocument();
+    // formatDate will format this, e.g. "Oct 1, 2023" or similar based on locale
+    // For robustness, check for part of the date or use a regex if format is complex
+    expect(screen.getByText(new Date('2023-10-01T10:00:00Z').toLocaleDateString('he-IL', { year: 'numeric', month: 'short', day: 'numeric' }))).toBeInTheDocument();
+
+
+    expect(screen.getByText('RECENT02')).toBeInTheDocument();
+    expect(screen.getByText('TestCo B')).toBeInTheDocument();
+    expect(screen.getByText(new Date('2023-09-30T12:00:00Z').toLocaleDateString('he-IL', { year: 'numeric', month: 'short', day: 'numeric' }))).toBeInTheDocument();
+  });
+
+  test('displays "no recent activity" message when no coupons are returned', async () => {
+    (couponApi.getRecentCoupons as jest.Mock).mockResolvedValue([]);
+    renderDashboard();
+
+    await waitFor(() => expect(couponApi.getRecentCoupons).toHaveBeenCalled());
+
+    expect(screen.getByText('No recent activity yet.')).toBeInTheDocument();
+    expect(screen.getByText('New coupons will appear here.')).toBeInTheDocument();
+  });
+
+  test('displays error message for recent activity on API failure', async () => {
+    const errorMessage = 'Failed to fetch recent activity';
+    (couponApi.getRecentCoupons as jest.Mock).mockRejectedValue(new Error(errorMessage));
+    renderDashboard();
+
+    await waitFor(() => expect(couponApi.getRecentCoupons).toHaveBeenCalled());
+
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    expect(screen.getByText('Try Again')).toBeInTheDocument();
+  });
+
+  test('allows retrying recent activity fetch after an error', async () => {
+    const errorMessage = 'Failed to fetch recent activity';
+    (couponApi.getRecentCoupons as jest.Mock)
+      .mockRejectedValueOnce(new Error(errorMessage)) // First call fails
+      .mockResolvedValueOnce(mockRecentCoupons); // Second call succeeds
+
+    renderDashboard();
+
+    // Wait for the initial error
+    await waitFor(() => {
+      expect(screen.getByText(errorMessage)).toBeInTheDocument();
+    });
+
+    // Click "Try Again"
+    fireEvent.click(screen.getByText('Try Again'));
+
+    // Wait for the successful fetch
+    await waitFor(() => {
+      expect(screen.getByText('RECENT01')).toBeInTheDocument();
+      expect(screen.getByText('TestCo A')).toBeInTheDocument();
+    });
+
+    expect(couponApi.getRecentCoupons).toHaveBeenCalledTimes(2);
+  });
+
+   test('main page loading and error for stats', async () => {
+    (couponApi.getStats as jest.Mock).mockReset(); // Clear default mock for this test
+    (couponApi.getStats as jest.Mock).mockImplementation(() => new Promise(() => {})); // Never resolves
+    (couponApi.getRecentCoupons as jest.Mock).mockResolvedValue([]); // Recent coupons load fine
+
+    renderDashboard();
+    // Should show main page loader because stats are still loading
+    expect(screen.getByTestId('loading-spinner')).toBeInTheDocument(); // Assuming LoadingSpinner has data-testid
+
+    // Now test stats error
+    (couponApi.getStats as jest.Mock).mockReset();
+    const statsErrorMessage = 'Failed to load stats';
+    (couponApi.getStats as jest.Mock).mockRejectedValue(new Error(statsErrorMessage));
+
+    // Need to unmount and remount or use a different approach if component doesn't re-render fully on prop change
+    // For simplicity, we'll re-render here.
+    const { rerender } = renderDashboard(); // Initial render
+
+    // To trigger a re-render that re-fetches or shows the error state
+    // In a real app, this might be a prop change or route change.
+    // Here, we rely on the initial fetch failing.
+     await waitFor(() => {
+        expect(screen.getByText(statsErrorMessage)).toBeInTheDocument();
+        // Ensure recent activity isn't shown, and main error takes precedence
+        expect(screen.queryByText('No recent activity yet.')).not.toBeInTheDocument();
+     });
+  });
+
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -103,6 +103,12 @@ export const couponApi = {
     return response.data;
   },
 
+  // Get recent coupons
+  getRecentCoupons: async (): Promise<Coupon[]> => {
+    const response = await api.get<Coupon[]>('/coupons/recent');
+    return response.data;
+  },
+
   // Health check
   healthCheck: async (): Promise<{ status: string; timestamp: string; uptime: number }> => {
     const response = await api.get('/health');


### PR DESCRIPTION
This commit introduces a new "Recent Activity" section to the dashboard, displaying the 5 most recently added coupons.

Key changes:

Backend:
- Added a new API endpoint `GET /api/coupons/recent` to fetch the 5 most recently added coupons.
- Resolved a potential routing conflict by renaming the stats endpoint from `/api/coupons/stats/summary` to `/api/coupons/summary/stats`.
- Added backend tests for the new `/api/coupons/recent` endpoint, covering successful responses, empty responses, sorting, and limits.

Frontend:
- Added a `getRecentCoupons` function to `frontend/src/services/api.ts` to call the new backend endpoint.
- Updated the `Dashboard` component (`frontend/src/pages/Dashboard.tsx`) to fetch and display recent activity.
- The "Recent Activity" section now shows coupon codes, company names, and dates for the latest coupons.
- Implemented loading and error states for the recent activity data.
- Added frontend tests for the `Dashboard` component to verify the display of recent activity, loading states, and error handling.