### PR TITLE
Fix: Correct route order in dev server for /api/coupons/recent

### DIFF
--- a/backend/server-dev.js
+++ b/backend/server-dev.js
@@ -206,6 +206,23 @@ app.get('/api/coupons', (req, res) => {
     }
 });
 
+// Get recent coupons
+app.get('/api/coupons/recent', (req, res) => {
+    try {
+        const couponsWithStatus = mockCoupons.map(updateCouponStatus);
+
+        // Sort by date_added (most recent first) and take the first 5
+        const recentCoupons = couponsWithStatus
+            .sort((a, b) => new Date(b.date_added).getTime() - new Date(a.date_added).getTime())
+            .slice(0, 5);
+
+        res.json(recentCoupons);
+    } catch (error) {
+        console.error('Error fetching recent coupons:', error);
+        res.status(500).json({ error: 'Failed to fetch recent activity' });
+    }
+});
+
 // Get single coupon
 app.get('/api/coupons/:id', (req, res) => {
     try {
@@ -384,23 +401,6 @@ app.get('/api/coupons/stats/summary', (req, res) => {
     } catch (error) {
         console.error('Error fetching stats:', error);
         res.status(500).json({ error: 'Failed to fetch statistics' });
-    }
-});
-
-// Get recent coupons
-app.get('/api/coupons/recent', (req, res) => {
-    try {
-        const couponsWithStatus = mockCoupons.map(updateCouponStatus);
-        
-        // Sort by date_added (most recent first) and take the first 5
-        const recentCoupons = couponsWithStatus
-            .sort((a, b) => new Date(b.date_added).getTime() - new Date(a.date_added).getTime())
-            .slice(0, 5);
-        
-        res.json(recentCoupons);
-    } catch (error) {
-        console.error('Error fetching recent coupons:', error);
-        res.status(500).json({ error: 'Failed to fetch recent activity' });
     }
 });
 


### PR DESCRIPTION
The development server (`server-dev.js`) had an incorrect route ordering where the parameterized route `/api/coupons/:id` was defined before the specific route `/api/coupons/recent`. This caused requests for `/api/coupons/recent` to be mistakenly handled by the `/:id` route, resulting in a 404 error with the message "Coupon not found" as "recent" was treated as a non-existent coupon ID.

This commit reorders the routes in `backend/server-dev.js` to define `/api/coupons/recent` before `/api/coupons/:id`, ensuring correct route matching.

The production server (`server.js` which uses `routes/coupons.js`) was not affected by this issue as its route definitions were already in the correct order.